### PR TITLE
<timer> was renamed in open-dylan/master to <profiling-timer>. following through

### DIFF
--- a/tracing-core/span.dylan
+++ b/tracing-core/span.dylan
@@ -17,7 +17,7 @@ define class <span> (<object>)
   slot span-annotations :: false-or(<span-annotation-vector>) = #f;
   slot span-data :: false-or(<vector>) = #f;
   slot span-start-time :: <timestamp>;
-  constant slot span-timer :: <timer> = make(<timer>);
+  constant slot span-timer :: <profiling-timer> = make(<profiling-timer>);
   slot span-duration :: false-or(<duration>) = #f;
   slot span-host :: <string> = "";
 end class <span>;

--- a/tracing-core/trace.dylan
+++ b/tracing-core/trace.dylan
@@ -5,7 +5,7 @@ Copyright: See LICENSE file in this distribution.
 
 define thread variable *current-spans* :: <list> = #();
 define variable *trace-host* :: <string> = "";
-define variable *trace-timer-since-start* = make(<timer>);
+define variable *trace-timer-since-start* = make(<profiling-timer>);
 define variable *trace-application-start-time* = get-current-timestamp();
 
 define method trace-push


### PR DESCRIPTION
It seems this won't work at our current release (https://github.com/dylan-lang/opendylan/blob/v2013.2/sources/common-dylan/timers.dylan#L7), the rename is active on master though (https://github.com/dylan-lang/opendylan/blob/master/sources/common-dylan/timers.dylan#L7);

this fixes issue https://github.com/dylan-foundry/tracing/issues/12
